### PR TITLE
Add initial support for Google Cloud SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project tries to adhere to [Semantic Versioning](http://semver.org/spec
 ## [Unreleased]
 _this space intentionally left blank_
 
+## [0.6.0] - 2023-01-23
+
+### In Code
+
+- Add initial support for Google Cloud SQL (@johanfleury)
+
 ## [0.5.0] - 2022-09-30
 
 ### In Code

--- a/pgbedrock/__init__.py
+++ b/pgbedrock/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.5.0'
+__version__ = '0.6.0'
 LOG_FORMAT = '%(levelname)s:%(filename)s:%(funcName)s:%(lineno)s - %(message)s'

--- a/pgbedrock/core_configure.py
+++ b/pgbedrock/core_configure.py
@@ -6,6 +6,7 @@ import psycopg2.extras
 
 from pgbedrock import LOG_FORMAT
 from pgbedrock import common
+from pgbedrock import context
 from pgbedrock.attributes import analyze_attributes
 from pgbedrock.memberships import analyze_memberships
 from pgbedrock.ownerships import analyze_ownerships
@@ -116,6 +117,11 @@ def configure(spec_path, host, port, user, password, dbname, prompt, attributes,
 
     db_connection = common.get_db_connection(host, port, dbname, user, password)
     cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    dbcontext = context.DatabaseContext(cursor, verbose)
+
+    if dbcontext.get_version_info().is_google_cloud:
+        click.secho('Running on Google Cloud SQL, password changes will be skipped.', fg='yellow')
 
     spec = load_spec(spec_path, cursor, verbose, attributes, memberships, ownerships, privileges)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,8 @@ from pgbedrock import LOG_FORMAT
 logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
+from pgbedrock import context
+
 
 Q_GET_ROLE_ATTRIBUTE = "SELECT {} FROM pg_authid WHERE rolname='{}';"
 NEW_USER = 'foobar'
@@ -163,6 +165,9 @@ def mockdbcontext():
                 return None
 
             return empty_func
+
+        def get_version_info(self):
+            return context.VersionInfo(postgres_version=None, redshift_version=None, is_redshift=None, is_google_cloud=False)
 
     return MockDatabaseContext()
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -482,7 +482,7 @@ def test_set_all_configs(mockdbcontext):
 @pytest.mark.parametrize('value, expected', [
         # No units
         (None, None),
-        ("foo", "foo")
+        ("foo", "foo"),
         ('1', 1),
         ('1.1', 1.1),
         # Memory units

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -65,8 +65,8 @@ def test_get_all_current_defaults(cursor):
     ('role1', 'missing_object_kind1', 'access1', set()),
     ('missing_role1', 'object_kind1', 'access', set()),
 ])
-def test_get_role_current_defaults(rolename, object_kind, access, expected):
-    dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=True)
+def test_get_role_current_defaults(cursor, rolename, object_kind, access, expected):
+    dbcontext = context.DatabaseContext(cursor, verbose=True)
     dbcontext._cache['get_all_current_defaults'] = lambda: {
         'role1': {
             'object_kind1': {
@@ -88,8 +88,8 @@ def test_get_role_current_defaults(rolename, object_kind, access, expected):
     # No entries exist --> False
     ('role1', common.ObjectName(DUMMY), 'objkind_does_not_exist', DUMMY, False),
 ])
-def test_has_default_privilege(rolename, schema, object_kind, access, expected):
-    dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=True)
+def test_has_default_privilege(cursor, rolename, schema, object_kind, access, expected):
+    dbcontext = context.DatabaseContext(cursor, verbose=True)
     dbcontext._cache['get_all_current_defaults'] = lambda: {
         'role1': {
             'tables': {
@@ -182,8 +182,8 @@ def test_get_all_current_nondefaults(cursor):
     ('role1', 'missing_object_kind1', 'access1', set()),
     ('missing_role1', 'object_kind1', 'access', set()),
 ])
-def test_get_role_current_nondefaults(rolename, object_kind, access, expected):
-    dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=True)
+def test_get_role_current_nondefaults(cursor, rolename, object_kind, access, expected):
+    dbcontext = context.DatabaseContext(cursor, verbose=True)
     dbcontext._cache['get_all_current_nondefaults'] = lambda: {
         'role1': {
             'object_kind1': {
@@ -208,8 +208,8 @@ def test_get_role_current_nondefaults(rolename, object_kind, access, expected):
         common.ObjectName(SCHEMAS[0], TABLES[1])
     ])),
 ])
-def test_get_role_objects_with_access(access, expected):
-    dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=True)
+def test_get_role_objects_with_access(cursor, access, expected):
+    dbcontext = context.DatabaseContext(cursor, verbose=True)
     dbcontext._cache['get_all_current_nondefaults'] = lambda: {
         ROLES[0]: {
             'tables': {
@@ -342,9 +342,9 @@ def test_get_all_role_attributes(cursor):
 
 
 
-def test_get_role_attributes():
+def test_get_role_attributes(cursor):
     expected = {'foo': 'bar'}
-    dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=True)
+    dbcontext = context.DatabaseContext(cursor, verbose=True)
     dbcontext._cache['get_all_role_attributes'] = lambda: {ROLES[0]: expected}
     actual = dbcontext.get_role_attributes(ROLES[0])
     assert actual == expected
@@ -352,8 +352,8 @@ def test_get_role_attributes():
 
 
 
-def test_get_role_attributes_role_does_not_exist():
-    dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=True)
+def test_get_role_attributes_role_does_not_exist(cursor):
+    dbcontext = context.DatabaseContext(cursor, verbose=True)
     dbcontext._cache['get_all_role_attributes'] = lambda: {}
     actual = dbcontext.get_role_attributes(ROLES[0])
     assert actual == dict()
@@ -366,8 +366,8 @@ def test_get_role_attributes_role_does_not_exist():
     ({ROLES[0]: {'rolsuper': True}}, True),
     ({}, False),
 ])
-def test_is_superuser(all_role_attributes, expected):
-    dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=True)
+def test_is_superuser(cursor, all_role_attributes, expected):
+    dbcontext = context.DatabaseContext(cursor, verbose=True)
     dbcontext._cache['get_all_role_attributes'] = lambda: all_role_attributes
     actual = dbcontext.is_superuser(ROLES[0])
     assert actual == expected
@@ -441,10 +441,10 @@ def test_get_all_memberships(cursor):
 
 
 
-def test_get_schema_owner():
+def test_get_schema_owner(cursor):
     schema = common.ObjectName('foo')
     expected_owner = 'bar'
-    dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=True)
+    dbcontext = context.DatabaseContext(cursor, verbose=True)
     dbcontext._cache['get_all_schemas_and_owners'] = lambda: {schema: expected_owner}
     actual = dbcontext.get_schema_owner(schema)
     assert actual == expected_owner
@@ -491,10 +491,10 @@ def test_get_all_nonschema_objects_and_owners(cursor):
     assert actual_again == actual
 
 
-def test_get_schema_objects():
+def test_get_schema_objects(cursor):
     schema = common.ObjectName('foo')
     expected = 'bar'
-    dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=False)
+    dbcontext = context.DatabaseContext(cursor, verbose=False)
     dbcontext._cache['get_all_nonschema_objects_and_owners'] = lambda: {
         common.ObjectName('foo'): expected
     }
@@ -502,8 +502,8 @@ def test_get_schema_objects():
     assert actual == expected
 
 
-def test_get_schema_objects_no_entry():
-    dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=False)
+def test_get_schema_objects_no_entry(cursor):
+    dbcontext = context.DatabaseContext(cursor, verbose=False)
     dbcontext._cache['get_all_nonschema_objects_and_owners'] = lambda: {
         common.ObjectName('foo'): 'bar',
     }
@@ -531,6 +531,7 @@ def test_get_version_info(cursor):
     assert isinstance(actual, context.VersionInfo)
     assert not actual.is_redshift
     assert not actual.redshift_version
+    assert not actual.is_google_cloud
     # We do not check the Postgres version since we test against multiple Postgres versions
 
     # Make sure that this data is cached for future use


### PR DESCRIPTION
Support Google Cloud SQL by reading roles on `pg_roles` instead of `pg_authid` and skipping password changes (when we detect that we’re running on Google Cloud).